### PR TITLE
Adds Support for gtk2 in color_theme.py

### DIFF
--- a/color_theme.py
+++ b/color_theme.py
@@ -35,6 +35,47 @@ replace_in_file(
 print("Done.")
 
 # ----------------------------------------------------------------------------
+# gtk-2
+# ----------------------------------------------------------------------------
+print("Updating gtk2-dark...")
+gtk2_folder = Path("yaru/gtk/src/dark/gtk-2.0")
+
+# replace orange
+replace_in_file(
+    gtk2_folder / "gtkrc",
+    "#E95420", 
+    COLOR_BRIGHT,
+    num_replacements=1
+)
+print("Done.")
+
+print("Updating gtk2-default...")
+gtk2_folder = Path("yaru/gtk/src/default/gtk-2.0")
+
+# replace orange
+replace_in_file(
+    gtk2_folder / "gtkrc",
+    "#E95420", 
+    COLOR_BRIGHT,
+    num_replacements=1
+)
+print("Done.")
+
+print("Updating gtk2-light...")
+gtk2_folder = Path("yaru/gtk/src/light/gtk-2.0")
+
+# replace orange
+replace_in_file(
+    gtk2_folder / "gtkrc",
+    "#E95420", 
+    COLOR_BRIGHT,
+    num_replacements=1
+)
+print("Done.")
+
+
+
+# ----------------------------------------------------------------------------
 # gtk-3
 # ----------------------------------------------------------------------------
 print("Updating gtk3...")


### PR DESCRIPTION
Hi @fkohlgrueber ,

This just adds color for gtk2-src files (gtkrc)
#### Paths: 
yaru/gtk/src/default/gtk2.0/gtkrc
yaru/gtk/src/dark/gtk2.0/gtkrc
yaru/gtk/src/light/gtk2.0/gtkrc


Ex: Inkscape takes color from gtkrc(see screenshot)
![inky](https://user-images.githubusercontent.com/54065734/88440898-f99e3780-ce2c-11ea-8e73-92971097f059.png)

Thanks!
